### PR TITLE
Adjusting for compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,9 @@
     ["@babel/env", {
       "targets": {
         "browsers": ["last 2 versions"]
-      }
+      },
+      "useBuiltIns": "usage",
+      "modules": "cjs"
     }],
     "@babel/react"
   ]

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -4,7 +4,6 @@ const fetchHar = require('fetch-har');
 const oasToHar = require('./lib/oas-to-har');
 const isAuthReady = require('./lib/is-auth-ready');
 const extensions = require('@readme/oas-extensions');
-const Waypoint = require('react-waypoint');
 
 const { Fragment } = React;
 
@@ -38,7 +37,6 @@ class Doc extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
     this.toggleAuth = this.toggleAuth.bind(this);
     this.hideResults = this.hideResults.bind(this);
-    this.waypointEntered = this.waypointEntered.bind(this);
     this.Params = createParams(this.oas);
 
     this.setApiKey();
@@ -110,10 +108,6 @@ class Doc extends React.Component {
 
   hideResults() {
     this.setState({ result: null });
-  }
-
-  waypointEntered() {
-    this.setState({ showEndpoint: true });
   }
 
   // TODO: I couldn't figure out why this existed
@@ -306,10 +300,6 @@ class Doc extends React.Component {
     const { doc } = this.props;
     const oas = this.oas;
 
-    const renderEndpoint = () => {
-      return this.renderEndpoint();
-    };
-
     return (
       <div className="hub-reference" id={`page-${doc.slug}`}>
         {
@@ -334,7 +324,7 @@ class Doc extends React.Component {
           <div className="hub-reference-right">&nbsp;</div>
         </div>
 
-        {renderEndpoint()}
+        {this.renderEndpoint()}
 
         {
           // TODO maybe we dont need to do this with a hidden input now

--- a/packages/api-explorer/src/Doc.jsx
+++ b/packages/api-explorer/src/Doc.jsx
@@ -307,13 +307,7 @@ class Doc extends React.Component {
     const oas = this.oas;
 
     const renderEndpoint = () => {
-      if (this.props.appearance.splitReferenceDocs) return this.renderEndpoint();
-
-      return (
-        <Waypoint onEnter={this.waypointEntered} fireOnRapidScroll={false} bottomOffset="-1%">
-          {this.state.showEndpoint && this.renderEndpoint()}
-        </Waypoint>
-      );
+      return this.renderEndpoint();
     };
 
     return (

--- a/packages/api-explorer/src/index.jsx
+++ b/packages/api-explorer/src/index.jsx
@@ -89,11 +89,12 @@ class ApiExplorer extends React.Component {
       <div className={`is-lang-${this.state.language}`}>
         <div
           id="hub-reference"
-          className={`content-body hub-reference-sticky hub-reference-theme-${this.props.appearance
-            .referenceLayout}`}
+          className={`content-body hub-reference-sticky hub-reference-theme-${
+            this.props.appearance.referenceLayout
+          }`}
         >
           {this.props.docs.map(doc => (
-            <VariablesContext.Provider value={this.props.variables}>
+            <VariablesContext.Provider value={this.props.variables} key={`doc-${doc._id}`}>
               <OauthContext.Provider value={this.props.oauth}>
                 <GlossaryTermsContext.Provider value={this.props.glossaryTerms}>
                   <SelectedAppContext.Provider value={this.state.selectedApp}>

--- a/packages/api-explorer/webpack.config.js
+++ b/packages/api-explorer/webpack.config.js
@@ -21,4 +21,8 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.json', '.jsx'],
   },
+  externals: {
+    react: 'react',
+    'prop-types': 'prop-types'
+  },
 };


### PR DESCRIPTION
This PR makes some changes to to fix issues with parameters/code examples not rendering, updates some of the bundling, and fixes some issues/warnings coming from react:
- Update [.babelrc](https://github.com/emm035/api-explorer/pull/1/files#diff-e56633f72ecc521128b3db6586074d2cR7) to write CommonJS
- Removes [waypoints code](https://github.com/emm035/api-explorer/pull/1/files#diff-c133bc65d8d3c64a537fd85e4b2514afL309) from Doc object (waypoints weren't being triggered)
- Adds a `key` prop to the [highest level provider](https://github.com/emm035/api-explorer/pull/1/files#diff-e4c5a9b5431ff6440ad731912e426ff8R97) being mapped in `index.js`
- [Externalized React and Prop-Types](https://github.com/emm035/api-explorer/pull/1/files#diff-cbdf16ca63ae8b6e9d27464803f1b290R24) so they aren't included in the bundle